### PR TITLE
Simplify RFC 2119 language

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -10,7 +10,7 @@ The document starts with definitions of the main terms, then covers the content 
 
 ## Definitions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://www.rfc-editor.org/info/bcp14) ([RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119), [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174)) when, and only when, they appear in UPPERCASE.
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in [BCP 14](https://www.rfc-editor.org/info/bcp14) ([RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119), [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174)) when, and only when, they appear in UPPERCASE.
 
 Organization is any organization with commercial or non-commercial scope, that is applying this specification, and corresponds to the term "vendor" in \[ISO.29147.2018\] and \[CERT.CVD\].
 
@@ -45,7 +45,7 @@ The Organization Vulnerability Reporting Policy is a document containing the fol
 - MUST describe the information the initial report SHOULD include to be processed  
 - MUST contain information on which vulnerability identification the Organization assigns  
 - MUST contain information on where the list of known vulnerabilities in the products of the Organization is located  
-- RECOMMENDED contain information how the Organization credits Researchers  
+- SHOULD contain information how the Organization credits Researchers  
 - SHOULD include information on the payments provided to Researchers for valid findings, if the Organization provides any; or information that the Organization does not pay for reports  
 - If the Organization has a bug bounty, the Policy SHOULD contain information about the bug bounty program
 
@@ -53,15 +53,15 @@ The Vulnerability Reporting Policy MAY be included into the Security Policy. The
 
 At least one of the reporting methods listed in the Policy MUST allow reporting without creating a dedicated account.
 
-If email is provided as a method of reporting vulnerabilities, the Organisation SHOULD provide the encryption key to be used for encrypted communications. The RECOMMENDED encryption methods and keys are OpenPGP (RFC 4880), and age [https://c2sp.org/age](https://c2sp.org/age)).
+If email is provided as a method of reporting vulnerabilities, the Organisation SHOULD provide the encryption key to be used for encrypted communications. The encryption methods and keys SHOULD be OpenPGP (RFC 4880) and age [https://c2sp.org/age](https://c2sp.org/age)).
 
 One method for reporting MAY be a ticketing system. If offered, the system SHOULD offer confidentiality of issues and responses. The ticketing system MAY use a third party service, e.g., in the case of a bug bounty program.
 
-It is RECOMMENDED that the list of reporting methods is provided in a machine-readable format.
+The list of reporting methods SHOULD be provided in a machine-readable format.
 
 The Policy MUST adhere to the Coordinated Vulnerability Disclosure principles, assuming coordination between all stakeholders; as opposed to “full disclosure” or “no disclosure”.
 
-If the Organization is distributing software in the source code form, the source code MUST include an URL to the reporting policy or an URL to the policy, and the specific Project information, if applicable. It is RECOMMENDED to use a separate, dedicated file with the name like SECURITY, SECURITY.md or SECURITY.txt. The Organization MAY distribute the complete content of the Policy in such a file.
+If the Organization is distributing software in the source code form, the source code MUST include an URL to the reporting policy or an URL to the policy, and the specific Project information, if applicable. The Organization SHOULD use a separate, dedicated file with the name like SECURITY, SECURITY.md or SECURITY.txt. The Organization MAY distribute the complete content of the Policy in such a file.
 
 If the Organization is distributing software in the binary form, the software MUST either
 
@@ -74,7 +74,7 @@ Organizations accept vulnerabilities from multiple sources and they MUST accept 
 
 ### External reporting
 
-Organizations MUST publish their Vulnerability Reporting Policy on their website, if they have one. It is RECOMMENDED to use a page name like “Security” or “How to report a vulnerability” or similar. Such a page MUST be publicly available.
+Organizations MUST publish their Vulnerability Reporting Policy on their website, if they have one. They SHOULD use a page name like “Security” or “How to report a vulnerability” or similar. Such a page MUST be publicly available.
 
 If an Organization is hosting multiple software Products, they MAY have specific clauses, for example a specific preferred reporting mechanism.
 
@@ -96,7 +96,7 @@ If during the analysis the organization finds out that the cause of a Vulnerabil
 
 In case if the upstream Organization does not provide a fix in a reasonable timeline, the Organization MAY provide a fix or a mitigation.
 
-Each Organization decides how to develop fixes for Vulnerabilities. It is RECOMMENDED that this development happens privately and all parts of the solution (fixes, mitigations, documentation, Vulnerability identification) become public at the same time with a bug fix release (if provided).
+Each Organization decides how to develop fixes for Vulnerabilities. This development SHOULD happen privately and all parts of the solution (fixes, mitigations, documentation, Vulnerability identification) become public at the same time with a bug fix release (if provided).
 
 ## Multi-party vulnerability handling and disclosure
 
@@ -108,15 +108,15 @@ In case of such a multi-party vulnerability handling, all parties SHOULD agree o
 
 ## Vulnerability publication
 
-The Organization MUST publish all resolved vulnerabilities. Each Organization MUST publish a list of all publicly known Vulnerabilities in their products. This publication SHOULD happen on a web page and it is RECOMMENDED to offer a machine-readable version.
+The Organization MUST publish all resolved vulnerabilities. Each Organization MUST publish a list of all publicly known Vulnerabilities in their products. This publication SHOULD happen on a web page and SHOULD offer a machine-readable version.
 
-The publication of the list of known Vulnerabilities takes a form of a list of their identification (one or multiple ones) and at least one link to a public resource describing this Vulnerability (at least the affected product and versions, affected configurations and a general description) and RECOMMENDED to include an estimation of severity of the Vulnerability. The Organization MAY include additional information.
+The publication of the list of known Vulnerabilities takes a form of a list of their identification (one or multiple ones) and at least one link to a public resource describing this Vulnerability (at least the affected product and versions, affected configurations and a general description) and SHOULD include an estimation of severity of the Vulnerability. The Organization MAY include additional information.
 
 The publication MUST include a Vulnerability identification from a public database. It MAY include additional identification numbers from public and private databases.
 
-It is STRONGLY RECOMMENDED that this information is also available in machine-readable format.
+This information SHOULD also available in machine-readable format.
 
-For higher severity Vulnerabilities, it is RECOMMENDED that the Organization also publishes an advisory containing information regarding affected configurations, possible mitigations and all information considered useful for users of the Product.
+For higher severity Vulnerabilities, the Organization SHOULD also publish an advisory containing information regarding affected configurations, possible mitigations and all information considered useful for users of the Product.
 
 ## References
 


### PR DESCRIPTION
Lower the cognitive load by reducing the RCF key words to five (and removing the synonyms):

* MUST
* MUST NOT
* SHOULD
* SHOULD NOT
* MAY

Update the text accordingly.