### PR TITLE
spec.md: unify vocabulary usage between vuln management and handling

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,12 +1,12 @@
-# Vulnerability handling for products with digital elements
+# Vulnerability management for products with digital elements
 
 ## Introduction
 
 Organizations need to handle reported vulnerabilities. The industry is agreeing on common practices, and they have been described in various guidelines.
 
-This specification describes in a formal way the needed elements of such a vulnerability handling procedure using the model of coordinated disclosure. Other models like “full disclosure” are out of scope of this document.
+This specification describes in a formal way the needed elements of such a vulnerability management procedure using the model of coordinated disclosure. Other models like “full disclosure” are out of scope of this document.
 
-The document starts with definitions of the main terms, then covers the content of a Vulnerability Reporting Policy. With those two elements, it then describes steps of a vulnerability handling process.
+The document starts with definitions of the main terms, then covers the content of a Vulnerability Reporting Policy. With those two elements, it then describes steps of a vulnerability management process.
 
 ## Definitions
 
@@ -86,25 +86,25 @@ Organizations MUST apply the same processes for internal and external vulnerabil
 
 Organizations SHOULD trace disclosed vulnerabilities in dependencies.
 
-## Vulnerability handling inside an organization
+## Vulnerability management inside an organization
 
 Organizations MUST clearly assign potential vulnerability management to a group or individuals.
 
 All Vulnerabilities MUST be resolved: either fixed, or mitigated, or documented. The resolution time depends on the vulnerability type, but it MUST be reasonable.
 
-If during the analysis the organization finds out that the cause of a Vulnerability is located in a product that is a dependency, the Organization MUST report the Vulnerability to the upstream project, using one of their official vulnerability reporting channels. The communication between multiple Organizations follows the rules of Coordinated Vulnerability Handling and Disclosure.
+If during the analysis the organization finds out that the cause of a Vulnerability is located in a product that is a dependency, the Organization MUST report the Vulnerability to the upstream project, using one of their official vulnerability reporting channels. The communication between multiple Organizations follows the rules of Coordinated Vulnerability Disclosure (CVD).
 
 In case if the upstream Organization does not provide a fix in a reasonable timeline, the Organization MAY provide a fix or a mitigation.
 
 Each Organization decides how to develop fixes for Vulnerabilities. This development SHOULD happen privately and all parts of the solution (fixes, mitigations, documentation, Vulnerability identification) become public at the same time with a bug fix release (if provided).
 
-## Multi-party vulnerability handling and disclosure
+## Multi-party vulnerability management and disclosure
 
-Sometimes the vulnerability handling and disclosure includes more parties than the Researcher and the Organization. It might include a case when the vulnerability is in a dependency, or if the analysis finds that multiple similar vulnerabilities exist in products with the same functionality, or even if the vulnerable code is shared between different Products.
+Sometimes the vulnerability management and disclosure includes more parties than the Researcher and the Organization. It might include a case when the vulnerability is in a dependency, or if the analysis finds that multiple similar vulnerabilities exist in products with the same functionality, or even if the vulnerable code is shared between different Products.
 
 In such a case, the Organization and Researcher MUST notify additional parties. They MAY decide to name a Coordinator, a party dealing with communication and synchronization between Organizations and Researchers.
 
-In case of such a multi-party vulnerability handling, all parties SHOULD agree on and release all the vulnerability information on a coordinated basis and on a coordinated date.
+In case of such a multi-party vulnerability management, all parties SHOULD agree on and release all the vulnerability information on a coordinated basis and on a coordinated date.
 
 ## Vulnerability publication
 


### PR DESCRIPTION
"Vulnerability handling" is a term frequently used to signify the process of resolving the vulnerability, while the disclosure is another process. This document covers both, so we prefer to use the general term "vulnerability management" in the general case.